### PR TITLE
Fixed typo.

### DIFF
--- a/src/services/filters/reducer.js
+++ b/src/services/filters/reducer.js
@@ -1,7 +1,7 @@
 import { UPDATE_FILTER } from './actionTypes';
 
 const initialState = {
-  item: []
+  items: []
 };
 
 export default function(state = initialState, action) {


### PR DESCRIPTION
`item` is not used. Reference: `src\components\Shelf\Filter\index.js`.