### PR TITLE
refactor: substr replace substring

### DIFF
--- a/src/components/Products/Product/Product.tsx
+++ b/src/components/Products/Product/Product.tsx
@@ -58,8 +58,8 @@ const Product = ({ product }: IProps) => {
       <S.Price>
         <S.Val>
           <small>{currencyFormat}</small>
-          <b>{formattedPrice.substr(0, formattedPrice.length - 3)}</b>
-          <span>{formattedPrice.substr(formattedPrice.length - 3, 3)}</span>
+          <b>{formattedPrice.substring(0, formattedPrice.length - 3)}</b>
+          <span>{formattedPrice.substring(formattedPrice.length - 3)}</span>
         </S.Val>
         {productInstallment}
       </S.Price>


### PR DESCRIPTION
substr is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards.

substring is recommend